### PR TITLE
ODM: stop duplicate tasks, make them identifiable, and make results recoverable

### DIFF
--- a/ODM/ODM.py
+++ b/ODM/ODM.py
@@ -757,20 +757,43 @@ class ODMManager:
         except Exception as e:
             slicer.util.errorDisplay(f"Failed to stop container:\n{str(e)}")
 
+    def _updateTaskButtons(self):
+        """
+        Single source of truth for the task buttons: Run is available only when no task
+        is tracked, and the task controls only when one is. Re-enabling Run while a task
+        is still tracked is what let a second click orphan the first task.
+        """
+        hasTask = self.webodmTask is not None
+        self.widget.launchWebODMTaskButton.setEnabled(not hasTask)
+        self.widget.stopMonitoringButton.setEnabled(hasTask)
+        self.widget.cancelTaskButton.setEnabled(hasTask)
+
     def onRunWebODMTask(self):
         """
         Create and execute a WebODM reconstruction task.
 
-        The button is held disabled for the whole call: the upload below runs on the UI
-        thread, and every click here queues a separate task on the node.
+        Run is disabled for the whole call (the upload runs on the UI thread, so clicks
+        would otherwise queue up behind it) and stays disabled afterwards for as long as
+        the created task is still being tracked.
         """
         self.widget.launchWebODMTaskButton.setEnabled(False)
         try:
             self._runWebODMTask()
         finally:
-            self.widget.launchWebODMTaskButton.setEnabled(True)
+            self._updateTaskButtons()
 
     def _runWebODMTask(self):
+        # Slicer tracks exactly one task. Starting another would overwrite webodmTask and
+        # webodmTimer, leaving the previous one running on the node with no way to monitor
+        # or cancel it from here.
+        if self.webodmTask is not None:
+            slicer.util.warningDisplay(
+                "A task is already being monitored.\n\n"
+                "Use 'Cancel Task' to stop it, or 'Stop Monitoring' to leave it running on "
+                "the node, before starting another one."
+            )
+            return
+
         try:
             from pyodm import Node
         except ImportError:
@@ -905,8 +928,6 @@ class ODMManager:
 
         self.widget.webodmLogTextEdit.clear()
         self.widget.webodmLogTextEdit.append(f"Task '{shortTaskName}' queued on {dashboardUrl}")
-        self.widget.stopMonitoringButton.setEnabled(True)
-        self.widget.cancelTaskButton.setEnabled(True)
 
         self.lastWebODMOutputLineIndex = 0
 
@@ -943,8 +964,7 @@ class ODMManager:
         """
         self._stopMonitoringTimer()
         self.webodmTask = None
-        self.widget.stopMonitoringButton.setEnabled(False)
-        self.widget.cancelTaskButton.setEnabled(False)
+        self._updateTaskButtons()
         self.widget.webodmLogTextEdit.append(
             "Stopped monitoring. The task is still running on the node -- see "
             f"{self.widget.nodeDashboardUrl()} to follow or cancel it."
@@ -982,13 +1002,12 @@ class ODMManager:
         self.widget.webodmLogTextEdit.append("Task canceled on the node.")
         self._stopMonitoringTimer()
         self.webodmTask = None
-        self.widget.stopMonitoringButton.setEnabled(False)
-        self.widget.cancelTaskButton.setEnabled(False)
+        self._updateTaskButtons()
 
     def queuedTaskCount(self):
         """
-        How many tasks are running or queued on the node, or None if it can't be asked.
-        Used to explain a task sitting at 'Queued, Progress: 0%'.
+        How many tasks are QUEUED or RUNNING on the node (this one included), or None if
+        it can't be asked. Used to explain a task sitting at 'Queued, Progress: 0%'.
         """
         try:
             from pyodm import Node
@@ -1019,11 +1038,13 @@ class ODMManager:
         statusLine = f"Status: {info.status.name}, Progress: {info.progress}%"
         if info.status.name.lower() == "queued":
             # "Queued, 0%" on its own reads as a hang. Say what it is waiting behind.
-            aheadCount = self.queuedTaskCount()
-            if aheadCount is not None and aheadCount > 1:
+            # NodeODM counts QUEUED+RUNNING including this task, so drop it to get the
+            # number actually ahead.
+            totalCount = self.queuedTaskCount()
+            if totalCount is not None and totalCount > 1:
                 statusLine += (
-                    f" -- {aheadCount} task(s) running or queued on this node; "
-                    f"yours is waiting its turn. See {self.widget.nodeDashboardUrl()}"
+                    f" -- {totalCount - 1} task(s) ahead of yours on this node. "
+                    f"See {self.widget.nodeDashboardUrl()}"
                 )
         self.widget.webodmLogTextEdit.append(statusLine)
         cursor = self.widget.webodmLogTextEdit.textCursor()
@@ -1043,15 +1064,13 @@ class ODMManager:
 
             self._stopMonitoringTimer()
             self.webodmTask = None
-            self.widget.stopMonitoringButton.setEnabled(False)
-            self.widget.cancelTaskButton.setEnabled(False)
+            self._updateTaskButtons()
         elif info.status.name.lower() in ["failed", "canceled"]:
             self.widget.webodmLogTextEdit.append("Task failed or canceled. Stopping.")
             slicer.app.processEvents()
             self._stopMonitoringTimer()
             self.webodmTask = None
-            self.widget.stopMonitoringButton.setEnabled(False)
-            self.widget.cancelTaskButton.setEnabled(False)
+            self._updateTaskButtons()
 
     def onImportModelClicked(self):
         """

--- a/ODM/ODM.py
+++ b/ODM/ODM.py
@@ -930,11 +930,16 @@ class ODMManager:
             autoCloseMsec=3000
         )
 
+        # Path only -- the folder is created at download time. Creating it here left an
+        # empty WebODM_<name> folder behind whenever a task was never downloaded (Stop
+        # Monitoring, a failure, a Slicer restart), which then looked like output and
+        # sent 'Import Reconstructed Model' hunting for an odm_texturing that never came.
         self.webodmOutDir = os.path.join(inputFolder, f"WebODM_{shortTaskName}")
-        os.makedirs(self.webodmOutDir, exist_ok=True)
 
         self.widget.webodmLogTextEdit.clear()
         self.widget.webodmLogTextEdit.append(f"Task '{shortTaskName}' queued on {dashboardUrl}")
+        self.widget.webodmLogTextEdit.append(f"  node task UUID: {self.webodmTask.uuid}")
+        self.widget.webodmLogTextEdit.append(f"  results will download to: {self.webodmOutDir}")
 
         self.lastWebODMOutputLineIndex = 0
 
@@ -953,17 +958,24 @@ class ODMManager:
     
     def generateShortTaskName(self, basePrefix, paramsDict):
         """
-        Generate a short task name based on prefix and parameter hash.
-        Similar to PhotoMasking's generateShortTaskName method.
+        Name a task uniquely: prefix, a hash of the parameters, and the start time.
+
+        The hash alone is a pure function of the parameters, so re-running the same
+        settings produced the same name every time -- two tasks on the node sharing one
+        name, both pointing at one WebODM_<name> folder, the second download landing on
+        top of the first. The timestamp is what makes a run identifiable; the hash is
+        kept so the settings are still readable at a glance.
         """
         import hashlib
         import json
-        
+        import datetime
+
         # Convert params to a stable JSON string
         paramsStr = json.dumps(paramsDict, sort_keys=True)
         hashObj = hashlib.sha256(paramsStr.encode('utf-8'))
         shortHash = hashObj.hexdigest()[:8]
-        return f"{basePrefix}_{shortHash}"
+        stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        return f"{basePrefix}_{shortHash}_{stamp}"
 
     def onStopMonitoring(self):
         """
@@ -1064,6 +1076,7 @@ class ODMManager:
             self.widget.webodmLogTextEdit.append(f"Task completed! Downloading results to {self.webodmOutDir} ...")
             slicer.app.processEvents()
             try:
+                os.makedirs(self.webodmOutDir, exist_ok=True)
                 self.webodmTask.download_assets(self.webodmOutDir)
                 slicer.util.infoDisplay(f"Results downloaded to:\n{self.webodmOutDir}")
             except Exception as e:
@@ -1088,13 +1101,15 @@ class ODMManager:
             slicer.util.errorDisplay("No input folder selected.")
             return
 
-        # Search for WebODM output folders
-        webodm_dirs = [d for d in os.listdir(inputFolder) if d.startswith("WebODM_")]
+        # Search for WebODM output folders. os.listdir is in filesystem order, so sort:
+        # task names end in a YYYYMMDD-HHMMSS stamp, which sorts chronologically, making
+        # the last entry genuinely the newest rather than whichever the OS happened to
+        # hand back last.
+        webodm_dirs = sorted(d for d in os.listdir(inputFolder) if d.startswith("WebODM_"))
         if not webodm_dirs:
             slicer.util.errorDisplay("No WebODM output folders found.")
             return
 
-        # For now, use the first one found (could add selection dialog)
         latest_dir = os.path.join(inputFolder, webodm_dirs[-1])
         odm_texturing = os.path.join(latest_dir, "odm_texturing")
         

--- a/ODM/ODM.py
+++ b/ODM/ODM.py
@@ -474,19 +474,26 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         """Resume monitoring a task that is already on the node"""
         self.webODMManager.onReconnectTaskClicked()
 
+    def sanitizeDatasetName(self, text):
+        """
+        Reduce a dataset name to characters that are safe in a folder name.
+
+        This names WebODM_<name> and WebODM_<name>.json on disk, so it has to hold for
+        anything the user types, not just names derived from a folder.
+        """
+        import re
+        cleaned = re.sub(r'[^A-Za-z0-9._-]+', '_', text or "").strip('_.')
+        return cleaned or "SlicerReconstruction"
+
     def datasetNameFromFolder(self, folder):
         """
         Name a dataset after the folder its photos came from.
 
         The name is all the node knows about a task: it has no idea which folder was
         uploaded. Left at the default, every task was called 'SlicerReconstruction' and
-        two different specimens were indistinguishable on the dashboard. Restricted to
-        characters that are safe in a folder name, since it also names WebODM_<name>.
+        two different specimens were indistinguishable on the dashboard.
         """
-        import re
-        base = os.path.basename(os.path.normpath(folder or ""))
-        base = re.sub(r'[^A-Za-z0-9._-]+', '_', base).strip('_.')
-        return base or "SlicerReconstruction"
+        return self.sanitizeDatasetName(os.path.basename(os.path.normpath(folder or "")))
 
     def onInputFolderChanged(self, folder):
         """Track the images folder, unless the user has named the dataset themselves."""
@@ -938,7 +945,9 @@ class ODMManager:
         params["max-concurrency"] = self.widget.maxConcurrencySpinBox.value
         
         # Generate task name based on parameters (creates a short hash-based name)
-        prefix = self.widget.datasetNameLineEdit.text.strip() or "SlicerReconstruction"
+        # Sanitize here too: the field is free text, and folder-tracking stops the moment
+        # the user types their own name, so this is the only guard on what they typed.
+        prefix = self.widget.sanitizeDatasetName(self.widget.datasetNameLineEdit.text.strip())
         shortTaskName = self.generateShortTaskName(prefix, params, inputFolder)
 
         # create_task uploads every file on the UI thread, which for a few hundred images
@@ -1154,10 +1163,18 @@ class ODMManager:
         return records
 
     def describeTask(self, info, records=None):
-        """One line per task for the reconnect picker."""
+        """
+        One line per task for the reconnect picker.
+
+        Leads with the UUID: the picker returns the chosen string and we map it back by
+        index, so two tasks rendering the same text would attach the wrong one -- and
+        unnamed tasks with matching status/date/count do collide. The UUID is unique by
+        construction, and it is also the first thing the NodeODM dashboard shows, so it
+        is what you match against by eye.
+        """
         stamp = info.date_created.strftime("%Y-%m-%d %H:%M") if info.date_created else "?"
         tag = "   <- from this folder" if records and info.uuid in records else ""
-        return (f"{info.name or '(unnamed)'}  |  {info.status.name}  |  "
+        return (f"{info.uuid[:8]}  |  {info.name or '(unnamed)'}  |  {info.status.name}  |  "
                 f"{stamp} UTC  |  {info.images_count} images{tag}")
 
     def onReconnectTaskClicked(self):
@@ -1349,11 +1366,18 @@ class ODMManager:
             slicer.util.errorDisplay("No input folder selected.")
             return
 
-        # Search for WebODM output folders. os.listdir is in filesystem order, so sort:
-        # task names end in a YYYYMMDD-HHMMSS stamp, which sorts chronologically, making
-        # the last entry genuinely the newest rather than whichever the OS happened to
-        # hand back last.
-        webodm_dirs = sorted(d for d in os.listdir(inputFolder) if d.startswith("WebODM_"))
+        # Results folders only. writeTaskRecord drops a WebODM_<name>.json beside each
+        # results folder, and "WebODM_X.json" sorts after "WebODM_X", so matching on the
+        # prefix alone would pick the record file every time.
+        #
+        # Order by mtime, not by name: a name leads with the dataset name and a settings
+        # hash, so lexicographic order stops being chronological as soon as either
+        # differs between runs. mtime is when the results actually landed.
+        webodm_dirs = sorted(
+            (d for d in os.listdir(inputFolder)
+             if d.startswith("WebODM_") and os.path.isdir(os.path.join(inputFolder, d))),
+            key=lambda d: os.path.getmtime(os.path.join(inputFolder, d))
+        )
         if not webodm_dirs:
             slicer.util.errorDisplay("No WebODM output folders found.")
             return

--- a/ODM/ODM.py
+++ b/ODM/ODM.py
@@ -57,6 +57,8 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         self.launchWebODMTaskButton = None
         self.webodmLogTextEdit = None
         self.stopMonitoringButton = None
+        self.cancelTaskButton = None
+        self.nodeDashboardLabel = None
         
         # NodeODM management
         self.launchWebODMButton = None
@@ -86,7 +88,7 @@ class ODMWidget(ScriptedLoadableModuleWidget):
             "min-num-features": [50000, 10000, 20000],
             "pc-filter": [1, 2, 3, 4, 5],
             "depthmap-resolution": [3072, 2048, 4096, 8192],
-            "matcher-type": ["bruteforce", "bow", "flann"],
+            "matcher-type": ["flann", "bow", "bruteforce"],
             "feature-type": ["dspsift", "akaze", "hahog", "orb", "sift"],
             "feature-quality": ["ultra", "medium", "high"],
             "pc-quality": ["high", "medium", "ultra"],
@@ -203,7 +205,18 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         self.nodePortSpinBox.setValue(3002)
         self.nodePortSpinBox.setToolTip("Port number on which NodeODM is listening. Commonly 3001 or 3002.")
         webodmTaskFormLayout.addRow("Node Port:", self.nodePortSpinBox)
-        
+
+        self.nodeDashboardLabel = qt.QLabel()
+        self.nodeDashboardLabel.setOpenExternalLinks(True)
+        self.nodeDashboardLabel.setToolTip(
+            "Opens the NodeODM dashboard in your browser.\n"
+            "Shows every task on this node (running, queued and finished) and lets you cancel them."
+        )
+        webodmTaskFormLayout.addRow("Node Dashboard:", self.nodeDashboardLabel)
+        self.nodeIPLineEdit.connect('textChanged(QString)', self.onNodeAddressChanged)
+        self.nodePortSpinBox.connect('valueChanged(int)', self.onNodeAddressChanged)
+        self.updateNodeDashboardLink()
+
         # WebODM parameter tooltips
         parameterTooltips = {
             "ignore-gsd": (
@@ -296,10 +309,14 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         # TODO: Add WebODM parameter controls here (will be added in next step)
         
         self.datasetNameLineEdit = qt.QLineEdit("SlicerReconstruction")
-        self.datasetNameLineEdit.setToolTip("Name of the dataset in WebODM.\\nThis will be the reconstruction folder label.")
+        self.datasetNameLineEdit.setToolTip("Name of the dataset in WebODM.\nThis will be the reconstruction folder label.")
         webodmTaskFormLayout.addRow("name:", self.datasetNameLineEdit)
         
-        self.launchWebODMTaskButton = qt.QPushButton("Run NodeODM Task With Selected Parameters (non-blocking)")
+        self.launchWebODMTaskButton = qt.QPushButton("Run NodeODM Task With Selected Parameters")
+        self.launchWebODMTaskButton.setToolTip(
+            "Uploads the images and queues one reconstruction task on the node.\n"
+            "Uploading can take several minutes for large image sets."
+        )
         webodmTaskFormLayout.addWidget(self.launchWebODMTaskButton)
         self.launchWebODMTaskButton.setEnabled(True)
         
@@ -307,9 +324,20 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         self.webodmLogTextEdit.setReadOnly(True)
         webodmTaskFormLayout.addRow("Console Log:", self.webodmLogTextEdit)
         
+        taskControlRow = qt.QHBoxLayout()
         self.stopMonitoringButton = qt.QPushButton("Stop Monitoring")
         self.stopMonitoringButton.setEnabled(False)
-        webodmTaskFormLayout.addWidget(self.stopMonitoringButton)
+        self.stopMonitoringButton.setToolTip(
+            "Stop updating this log. The task keeps running on the node.\n"
+            "Use 'Cancel Task' to actually stop it."
+        )
+        taskControlRow.addWidget(self.stopMonitoringButton)
+
+        self.cancelTaskButton = qt.QPushButton("Cancel Task")
+        self.cancelTaskButton.setEnabled(False)
+        self.cancelTaskButton.setToolTip("Cancel the monitored task on the node itself.")
+        taskControlRow.addWidget(self.cancelTaskButton)
+        webodmTaskFormLayout.addRow(taskControlRow)
         
         self.importModelButton = qt.QPushButton("Import Reconstructed Model")
         self.layout.addWidget(self.importModelButton)
@@ -339,6 +367,7 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         self.stopWebODMButton.connect('clicked(bool)', self.onStopNodeClicked)
         self.launchWebODMTaskButton.connect('clicked(bool)', self.onRunWebODMTask)
         self.stopMonitoringButton.connect('clicked(bool)', self.onStopMonitoring)
+        self.cancelTaskButton.connect('clicked(bool)', self.onCancelTaskClicked)
         self.importModelButton.connect('clicked(bool)', self.onImportModelClicked)
         # self.saveTaskButton.connect('clicked(bool)', self.onSaveTaskClicked)
         # self.restoreTaskButton.connect('clicked(bool)', self.onRestoreTaskClicked)
@@ -365,7 +394,7 @@ class ODMWidget(ScriptedLoadableModuleWidget):
             os.chmod(self.webODMLocalFolder, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
             logging.info(f"WebODM folder created and permissions set: {self.webODMLocalFolder}")
         except Exception as e:
-            slicer.util.errorDisplay(f"Failed to create or set permissions for WebODM folder:\\n{str(e)}")
+            slicer.util.errorDisplay(f"Failed to create or set permissions for WebODM folder:\n{str(e)}")
     
     def _ensurePyODMInstalled(self):
         """Check if pyodm is installed, and install it if missing."""
@@ -378,13 +407,13 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         
         # Ask user to install
         if not slicer.util.confirmOkCancelDisplay(
-            "The ODM module requires the 'pyodm' Python package.\\n\\n"
+            "The ODM module requires the 'pyodm' Python package.\n\n"
             "Install it now?",
             "Install pyodm"
         ):
             slicer.util.warningDisplay(
-                "pyodm is required for this module to function.\\n"
-                "You can install it manually via:\\n"
+                "pyodm is required for this module to function.\n"
+                "You can install it manually via:\n"
                 "pip install pyodm"
             )
             return
@@ -393,7 +422,7 @@ class ODMWidget(ScriptedLoadableModuleWidget):
             slicer.util.pip_install("pyodm")
             slicer.util.infoDisplay("pyodm installed successfully!")
         except Exception as e:
-            slicer.util.errorDisplay(f"Failed to install pyodm:\\n{e}\\n\\nPlease install manually:\\npip install pyodm")
+            slicer.util.errorDisplay(f"Failed to install pyodm:\n{e}\n\nPlease install manually:\npip install pyodm")
 
     def onLaunchWebODMClicked(self):
         """Launch NodeODM container with GPU support on port 3002"""
@@ -410,7 +439,23 @@ class ODMWidget(ScriptedLoadableModuleWidget):
     def onStopMonitoring(self):
         """Stop monitoring the current task"""
         self.webODMManager.onStopMonitoring()
-    
+
+    def onCancelTaskClicked(self):
+        """Cancel the monitored task on the node"""
+        self.webODMManager.onCancelTaskClicked()
+
+    def nodeDashboardUrl(self):
+        """URL of the NodeODM dashboard for the currently configured node."""
+        return f"http://{self.nodeIPLineEdit.text.strip()}:{self.nodePortSpinBox.value}"
+
+    def onNodeAddressChanged(self, unusedValue=None):
+        """Keep the dashboard link in sync with the IP/port fields."""
+        self.updateNodeDashboardLink()
+
+    def updateNodeDashboardLink(self):
+        url = self.nodeDashboardUrl()
+        self.nodeDashboardLabel.setText(f'<a href="{url}">{url}</a>')
+
     def onImportModelClicked(self):
         """Import the reconstructed 3D model into Slicer"""
         self.webODMManager.onImportModelClicked()
@@ -601,7 +646,7 @@ class ODMManager:
         """
         proceed = slicer.util.confirmYesNoDisplay(
             "This action will ensure nodeodm:gpu is installed (pull if needed), "
-            "stop any running container on port 3002, and launch a new one.\\n\\n"
+            "stop any running container on port 3002, and launch a new one.\n\n"
             "Proceed?"
         )
         if not proceed:
@@ -612,7 +657,7 @@ class ODMManager:
         try:
             subprocess.run(["docker", "--version"], check=True, capture_output=True)
         except Exception as e:
-            slicer.util.warningDisplay(f"Docker not found or not in PATH.\\nError: {str(e)}")
+            slicer.util.warningDisplay(f"Docker not found or not in PATH.\nError: {str(e)}")
             return
         
         # Check if image exists, pull if needed
@@ -677,7 +722,7 @@ class ODMManager:
             slicer.app.settings().setValue("ODM/WebODMIP", "127.0.0.1")
             slicer.app.settings().setValue("ODM/WebODMPort", "3002")
         except Exception as e:
-            slicer.util.errorDisplay(f"Failed to launch WebODM container:\\n{str(e)}")
+            slicer.util.errorDisplay(f"Failed to launch WebODM container:\n{str(e)}")
 
     def onStopNodeClicked(self):
         """
@@ -687,7 +732,7 @@ class ODMManager:
 
         if jobInProgress:
             proceed = slicer.util.confirmYesNoDisplay(
-                "A WebODM task appears to be in progress. Stopping the node now will cancel that task.\\n\\n"
+                "A WebODM task appears to be in progress. Stopping the node now will cancel that task.\n\n"
                 "Do you want to continue?"
             )
             if not proceed:
@@ -710,12 +755,22 @@ class ODMManager:
                     subprocess.run(["docker", "stop", cid], check=True)
             slicer.util.infoDisplay("NodeODM container stopped.")
         except Exception as e:
-            slicer.util.errorDisplay(f"Failed to stop container:\\n{str(e)}")
+            slicer.util.errorDisplay(f"Failed to stop container:\n{str(e)}")
 
     def onRunWebODMTask(self):
         """
-        Create and execute a WebODM reconstruction task
+        Create and execute a WebODM reconstruction task.
+
+        The button is held disabled for the whole call: the upload below runs on the UI
+        thread, and every click here queues a separate task on the node.
         """
+        self.widget.launchWebODMTaskButton.setEnabled(False)
+        try:
+            self._runWebODMTask()
+        finally:
+            self.widget.launchWebODMTaskButton.setEnabled(True)
+
+    def _runWebODMTask(self):
         try:
             from pyodm import Node
         except ImportError:
@@ -727,7 +782,7 @@ class ODMManager:
         try:
             node = Node(node_ip, node_port)
         except Exception as e:
-            slicer.util.errorDisplay(f"Failed to connect to Node at {node_ip}:{node_port}\\n{str(e)}")
+            slicer.util.errorDisplay(f"Failed to connect to Node at {node_ip}:{node_port}\n{str(e)}")
             return
 
         inputFolder = self.widget.inputFolderSelector.directory
@@ -761,6 +816,30 @@ class ODMManager:
         else:
             slicer.util.infoDisplay("No combined_gcp_list.txt found. Proceeding without GCP...")
 
+        # Node.__init__ does not talk to the network, so this is the first call that
+        # actually proves the node is up -- and it tells us what is already queued.
+        dashboardUrl = self.widget.nodeDashboardUrl()
+        try:
+            nodeInfo = node.info()
+        except Exception as e:
+            slicer.util.errorDisplay(
+                f"Could not reach NodeODM at {dashboardUrl}\n\n{str(e)}\n\n"
+                "Is the node running? Use 'Launch NodeODM' above to start it."
+            )
+            return
+
+        queuedCount = nodeInfo.task_queue_count or 0
+        if queuedCount > 0:
+            proceed = slicer.util.confirmYesNoDisplay(
+                f"This node already has {queuedCount} task(s) running or queued.\n\n"
+                "A new task waits in line behind them, and will just report "
+                "'Queued, Progress: 0%' until they finish.\n\n"
+                f"Review or cancel existing tasks at:\n{dashboardUrl}\n\n"
+                "Queue another task anyway?"
+            )
+            if not proceed:
+                return
+
         # Build parameters from baseline + UI selections
         params = dict(self.widget.baselineParams)
 
@@ -785,21 +864,49 @@ class ODMManager:
         prefix = self.widget.datasetNameLineEdit.text.strip() or "SlicerReconstruction"
         shortTaskName = self.generateShortTaskName(prefix, params)
 
-        slicer.util.infoDisplay("Creating WebODM Task (non-blocking). Upload may take time...")
+        # create_task uploads every file on the UI thread, which for a few hundred images
+        # means minutes of frozen application. Drive a progress dialog from pyodm's
+        # callback so the upload is visibly alive.
+        fileCount = len(files_to_upload)
+        progressDialog = slicer.util.createProgressDialog(
+            windowTitle="Creating NodeODM Task",
+            labelText=f"Uploading {fileCount} file(s) to NodeODM...",
+            maximum=100
+        )
+        progressDialog.setCancelButton(None)
+        progressDialog.show()
+        slicer.app.processEvents()
+
+        def onUploadProgress(percent):
+            progressDialog.labelText = f"Uploading {fileCount} file(s) to NodeODM... {percent:.0f}%"
+            progressDialog.setValue(int(percent))
+            slicer.app.processEvents()
 
         try:
-            self.webodmTask = node.create_task(files=files_to_upload, options=params, name=shortTaskName)
+            self.webodmTask = node.create_task(
+                files=files_to_upload,
+                options=params,
+                name=shortTaskName,
+                progress_callback=onUploadProgress
+            )
         except Exception as e:
-            slicer.util.errorDisplay(f"Task creation failed:\\n{str(e)}")
+            slicer.util.errorDisplay(f"Task creation failed:\n{str(e)}")
             return
+        finally:
+            progressDialog.close()
 
-        slicer.util.infoDisplay(f"Task '{shortTaskName}' created successfully. Monitoring progress...")
+        slicer.util.infoDisplay(
+            f"Task '{shortTaskName}' created successfully. Monitoring progress...",
+            autoCloseMsec=3000
+        )
 
         self.webodmOutDir = os.path.join(inputFolder, f"WebODM_{shortTaskName}")
         os.makedirs(self.webodmOutDir, exist_ok=True)
 
         self.widget.webodmLogTextEdit.clear()
+        self.widget.webodmLogTextEdit.append(f"Task '{shortTaskName}' queued on {dashboardUrl}")
         self.widget.stopMonitoringButton.setEnabled(True)
+        self.widget.cancelTaskButton.setEnabled(True)
 
         self.lastWebODMOutputLineIndex = 0
 
@@ -834,13 +941,61 @@ class ODMManager:
         """
         Stop monitoring the current task (task continues on server)
         """
+        self._stopMonitoringTimer()
+        self.webodmTask = None
+        self.widget.stopMonitoringButton.setEnabled(False)
+        self.widget.cancelTaskButton.setEnabled(False)
+        self.widget.webodmLogTextEdit.append(
+            "Stopped monitoring. The task is still running on the node -- see "
+            f"{self.widget.nodeDashboardUrl()} to follow or cancel it."
+        )
+
+    def _stopMonitoringTimer(self):
         if self.webodmTimer:
             self.webodmTimer.stop()
             self.webodmTimer.deleteLater()
             self.webodmTimer = None
+
+    def onCancelTaskClicked(self):
+        """
+        Cancel the monitored task on the node itself (unlike Stop Monitoring,
+        which only stops Slicer from watching it).
+        """
+        if not self.webodmTask:
+            slicer.util.infoDisplay("No task is currently being monitored.")
+            return
+
+        if not slicer.util.confirmYesNoDisplay(
+            "Cancel the monitored task on the node?\n\nThis cannot be undone."
+        ):
+            return
+
+        try:
+            self.webodmTask.cancel()
+        except Exception as e:
+            slicer.util.warningDisplay(
+                f"Failed to cancel the task:\n{str(e)}\n\n"
+                f"You can also cancel it at {self.widget.nodeDashboardUrl()}"
+            )
+            return
+
+        self.widget.webodmLogTextEdit.append("Task canceled on the node.")
+        self._stopMonitoringTimer()
         self.webodmTask = None
         self.widget.stopMonitoringButton.setEnabled(False)
-        self.widget.webodmLogTextEdit.append("Stopped monitoring.")
+        self.widget.cancelTaskButton.setEnabled(False)
+
+    def queuedTaskCount(self):
+        """
+        How many tasks are running or queued on the node, or None if it can't be asked.
+        Used to explain a task sitting at 'Queued, Progress: 0%'.
+        """
+        try:
+            from pyodm import Node
+            node = Node(self.widget.nodeIPLineEdit.text.strip(), self.widget.nodePortSpinBox.value)
+            return node.info().task_queue_count
+        except Exception:
+            return None
 
     def checkWebODMTaskStatus(self):
         """
@@ -861,7 +1016,16 @@ class ODMManager:
                 self.widget.webodmLogTextEdit.append(line)
             self.lastWebODMOutputLineIndex += len(newLines)
 
-        self.widget.webodmLogTextEdit.append(f"Status: {info.status.name}, Progress: {info.progress}%")
+        statusLine = f"Status: {info.status.name}, Progress: {info.progress}%"
+        if info.status.name.lower() == "queued":
+            # "Queued, 0%" on its own reads as a hang. Say what it is waiting behind.
+            aheadCount = self.queuedTaskCount()
+            if aheadCount is not None and aheadCount > 1:
+                statusLine += (
+                    f" -- {aheadCount} task(s) running or queued on this node; "
+                    f"yours is waiting its turn. See {self.widget.nodeDashboardUrl()}"
+                )
+        self.widget.webodmLogTextEdit.append(statusLine)
         cursor = self.widget.webodmLogTextEdit.textCursor()
         cursor.movePosition(qt.QTextCursor.End)
         self.widget.webodmLogTextEdit.setTextCursor(cursor)
@@ -873,25 +1037,21 @@ class ODMManager:
             slicer.app.processEvents()
             try:
                 self.webodmTask.download_assets(self.webodmOutDir)
-                slicer.util.infoDisplay(f"Results downloaded to:\\n{self.webodmOutDir}")
+                slicer.util.infoDisplay(f"Results downloaded to:\n{self.webodmOutDir}")
             except Exception as e:
                 slicer.util.warningDisplay(f"Download failed: {str(e)}")
 
-            if self.webodmTimer:
-                self.webodmTimer.stop()
-                self.webodmTimer.deleteLater()
-                self.webodmTimer = None
+            self._stopMonitoringTimer()
             self.webodmTask = None
             self.widget.stopMonitoringButton.setEnabled(False)
+            self.widget.cancelTaskButton.setEnabled(False)
         elif info.status.name.lower() in ["failed", "canceled"]:
             self.widget.webodmLogTextEdit.append("Task failed or canceled. Stopping.")
             slicer.app.processEvents()
-            if self.webodmTimer:
-                self.webodmTimer.stop()
-                self.webodmTimer.deleteLater()
-                self.webodmTimer = None
+            self._stopMonitoringTimer()
             self.webodmTask = None
             self.widget.stopMonitoringButton.setEnabled(False)
+            self.widget.cancelTaskButton.setEnabled(False)
 
     def onImportModelClicked(self):
         """
@@ -922,7 +1082,7 @@ class ODMManager:
             return
 
         obj_path = os.path.join(odm_texturing, obj_files[0])
-        slicer.util.infoDisplay(f"Importing model from:\\n{obj_path}")
+        slicer.util.infoDisplay(f"Importing model from:\n{obj_path}")
 
         try:
             modelNode = slicer.util.loadModel(obj_path)
@@ -932,7 +1092,7 @@ class ODMManager:
                 layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutFourUpView)
                 slicer.util.infoDisplay("Model imported successfully!")
         except Exception as e:
-            slicer.util.errorDisplay(f"Failed to import model:\\n{str(e)}")
+            slicer.util.errorDisplay(f"Failed to import model:\n{str(e)}")
 
 
 class ODMLogic(ScriptedLoadableModuleLogic):

--- a/ODM/ODM.py
+++ b/ODM/ODM.py
@@ -102,6 +102,8 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         # Dataset name and concurrency
         self.datasetNameLineEdit = None
         self.maxConcurrencySpinBox = None
+        # Set once the user types their own dataset name; stops it tracking the folder.
+        self._datasetNameEdited = False
         
         # GCP (Ground Control Points)
         self.findGCPScriptSelector = None
@@ -310,7 +312,12 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         # TODO: Add WebODM parameter controls here (will be added in next step)
         
         self.datasetNameLineEdit = qt.QLineEdit("SlicerReconstruction")
-        self.datasetNameLineEdit.setToolTip("Name of the dataset in WebODM.\nThis will be the reconstruction folder label.")
+        self.datasetNameLineEdit.setToolTip(
+            "Labels this dataset on the node, and names the WebODM_<name> results folder.\n\n"
+            "Defaults to the images folder's own name (e.g. UWBM_82409), so a task on the node\n"
+            "says which photos it came from rather than only when it ran.\n"
+            "Type your own and it stops following the folder."
+        )
         webodmTaskFormLayout.addRow("name:", self.datasetNameLineEdit)
         
         self.launchWebODMTaskButton = qt.QPushButton("Run NodeODM Task With Selected Parameters")
@@ -381,6 +388,13 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         self.cancelTaskButton.connect('clicked(bool)', self.onCancelTaskClicked)
         self.reconnectTaskButton.connect('clicked(bool)', self.onReconnectTaskClicked)
         self.importModelButton.connect('clicked(bool)', self.onImportModelClicked)
+
+        # Keep the dataset name following the images folder until the user overrides it.
+        # textEdited fires only for real typing, not for setText, so the flag below is
+        # never tripped by our own updates.
+        self.inputFolderSelector.connect('directoryChanged(QString)', self.onInputFolderChanged)
+        self.datasetNameLineEdit.connect('textEdited(QString)', self.onDatasetNameEdited)
+        self.onInputFolderChanged(self.inputFolderSelector.directory)
         # self.saveTaskButton.connect('clicked(bool)', self.onSaveTaskClicked)
         # self.restoreTaskButton.connect('clicked(bool)', self.onRestoreTaskClicked)
         
@@ -459,6 +473,29 @@ class ODMWidget(ScriptedLoadableModuleWidget):
     def onReconnectTaskClicked(self):
         """Resume monitoring a task that is already on the node"""
         self.webODMManager.onReconnectTaskClicked()
+
+    def datasetNameFromFolder(self, folder):
+        """
+        Name a dataset after the folder its photos came from.
+
+        The name is all the node knows about a task: it has no idea which folder was
+        uploaded. Left at the default, every task was called 'SlicerReconstruction' and
+        two different specimens were indistinguishable on the dashboard. Restricted to
+        characters that are safe in a folder name, since it also names WebODM_<name>.
+        """
+        import re
+        base = os.path.basename(os.path.normpath(folder or ""))
+        base = re.sub(r'[^A-Za-z0-9._-]+', '_', base).strip('_.')
+        return base or "SlicerReconstruction"
+
+    def onInputFolderChanged(self, folder):
+        """Track the images folder, unless the user has named the dataset themselves."""
+        if self._datasetNameEdited:
+            return
+        self.datasetNameLineEdit.setText(self.datasetNameFromFolder(folder))
+
+    def onDatasetNameEdited(self, unusedText=None):
+        self._datasetNameEdited = True
 
     def nodeDashboardUrl(self):
         """URL of the NodeODM dashboard for the currently configured node."""
@@ -902,7 +939,7 @@ class ODMManager:
         
         # Generate task name based on parameters (creates a short hash-based name)
         prefix = self.widget.datasetNameLineEdit.text.strip() or "SlicerReconstruction"
-        shortTaskName = self.generateShortTaskName(prefix, params)
+        shortTaskName = self.generateShortTaskName(prefix, params, inputFolder)
 
         # create_task uploads every file on the UI thread, which for a few hundred images
         # means minutes of frozen application. Drive a progress dialog from pyodm's
@@ -958,6 +995,11 @@ class ODMManager:
         self.widget.webodmLogTextEdit.append(f"  node task UUID: {self.webodmTask.uuid}")
         self.widget.webodmLogTextEdit.append(f"  results will download to: {self.webodmOutDir}")
 
+        recordPath = self.writeTaskRecord(
+            inputFolder, shortTaskName, dashboardUrl, params, len(all_images))
+        if recordPath:
+            self.widget.webodmLogTextEdit.append(f"  task record: {recordPath}")
+
         self.lastWebODMOutputLineIndex = 0
 
         if self.webodmTimer:
@@ -973,7 +1015,23 @@ class ODMManager:
         if hasattr(self.widget, 'saveTaskButton') and self.widget.saveTaskButton:
             self.widget.saveTaskButton.enabled = True
     
-    def generateShortTaskName(self, basePrefix, paramsDict):
+    def uniqueTaskName(self, inputFolder, name):
+        """
+        Make sure the name is not already spoken for on disk.
+
+        The stamp has one-second resolution, so two jobs submitted inside the same second
+        get the same name -- and a colliding name means the second job's record and
+        results land on top of the first's. Rare with real uploads, silent when it does
+        happen, so check rather than assume.
+        """
+        candidate, n = name, 1
+        while (os.path.exists(self.taskRecordPath(inputFolder, candidate)) or
+               os.path.exists(os.path.join(inputFolder, f"WebODM_{candidate}"))):
+            n += 1
+            candidate = f"{name}-{n}"
+        return candidate
+
+    def generateShortTaskName(self, basePrefix, paramsDict, inputFolder=None):
         """
         Name a task uniquely: prefix, a hash of the parameters, and the start time.
 
@@ -992,7 +1050,8 @@ class ODMManager:
         hashObj = hashlib.sha256(paramsStr.encode('utf-8'))
         shortHash = hashObj.hexdigest()[:8]
         stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-        return f"{basePrefix}_{shortHash}_{stamp}"
+        name = f"{basePrefix}_{shortHash}_{stamp}"
+        return self.uniqueTaskName(inputFolder, name) if inputFolder else name
 
     def onStopMonitoring(self):
         """
@@ -1040,11 +1099,66 @@ class ODMManager:
         self.webodmTask = None
         self._updateTaskButtons()
 
-    def describeTask(self, info):
+    def taskRecordPath(self, inputFolder, taskName):
+        """The record sits beside the results: WebODM_<name>.json next to WebODM_<name>/."""
+        return os.path.join(inputFolder, f"WebODM_{taskName}.json")
+
+    def writeTaskRecord(self, inputFolder, taskName, dashboardUrl, params, imageCount):
+        """
+        Write down the tie between this folder and the node's task.
+
+        The node's UUID is the only identifier that is unique by construction, but it
+        lives only on the node -- which forgets finished tasks after 48h by default. The
+        record is what survives that, plus Stop Monitoring and Slicer restarts, and it
+        makes an images folder self-describing: one .json per job submitted from it,
+        sitting next to the results folder it will produce.
+        """
+        import datetime
+        record = {
+            "uuid": self.webodmTask.uuid,
+            "name": taskName,
+            "node": dashboardUrl,
+            "created": datetime.datetime.now().isoformat(timespec="seconds"),
+            "images_folder": inputFolder,
+            "image_count": imageCount,
+            "output_folder": f"WebODM_{taskName}",
+            "options": params,
+        }
+        path = self.taskRecordPath(inputFolder, taskName)
+        try:
+            with open(path, "w") as f:
+                json.dump(record, f, indent=2, sort_keys=True)
+        except Exception as e:
+            # A record is a convenience; never fail a live task over it.
+            self.widget.webodmLogTextEdit.append(f"  (could not write task record: {e})")
+            return None
+        return path
+
+    def readTaskRecords(self, inputFolder):
+        """uuid -> record, for every job submitted from this folder."""
+        records = {}
+        try:
+            names = os.listdir(inputFolder)
+        except Exception:
+            return records
+        for fn in names:
+            if not (fn.startswith("WebODM_") and fn.endswith(".json")):
+                continue
+            try:
+                with open(os.path.join(inputFolder, fn)) as f:
+                    rec = json.load(f)
+            except Exception:
+                continue  # hand-edited or truncated; ignore rather than break the picker
+            if isinstance(rec, dict) and rec.get("uuid"):
+                records[rec["uuid"]] = rec
+        return records
+
+    def describeTask(self, info, records=None):
         """One line per task for the reconnect picker."""
         stamp = info.date_created.strftime("%Y-%m-%d %H:%M") if info.date_created else "?"
+        tag = "   <- from this folder" if records and info.uuid in records else ""
         return (f"{info.name or '(unnamed)'}  |  {info.status.name}  |  "
-                f"{stamp} UTC  |  {info.images_count} images")
+                f"{stamp} UTC  |  {info.images_count} images{tag}")
 
     def onReconnectTaskClicked(self):
         """
@@ -1104,8 +1218,11 @@ class ODMManager:
             )
             return
 
+        # Cross-reference the node's tasks against the records written from this folder,
+        # so the picker can say which of them are yours.
+        records = self.readTaskRecords(inputFolder)
         tasks.sort(key=lambda i: i.date_created, reverse=True)
-        labels = [self.describeTask(i) for i in tasks]
+        labels = [self.describeTask(i, records) for i in tasks]
 
         # PythonQt's binding for QInputDialog.getItem returns just the selected string
         # (empty on cancel), not the (value, ok) tuple the C++/PyQt API uses.
@@ -1120,15 +1237,21 @@ class ODMManager:
         if not chosen or chosen not in labels:
             return
 
-        self.attachToTask(node, tasks[labels.index(chosen)], inputFolder, dashboardUrl)
+        self.attachToTask(node, tasks[labels.index(chosen)], inputFolder, dashboardUrl, records)
 
-    def attachToTask(self, node, info, inputFolder, dashboardUrl):
+    def attachToTask(self, node, info, inputFolder, dashboardUrl, records=None):
         """Resume monitoring an existing node task and route its results to disk."""
         self.webodmTask = node.get_task(info.uuid)
 
-        # The task name is the folder key (WebODM_<name>), which is why names carry a
-        # timestamp. A task created outside Slicer may be unnamed; fall back to its UUID.
-        folderKey = info.name or f"task_{info.uuid[:8]}"
+        # A record written when we submitted the task is authoritative about where its
+        # results belong. Failing that, fall back to the task name (which is what names
+        # WebODM_<name>), and for tasks created outside Slicer, which have no name, to
+        # the UUID.
+        record = (records or {}).get(info.uuid)
+        if record and record.get("output_folder"):
+            folderKey = record["output_folder"][len("WebODM_"):]
+        else:
+            folderKey = info.name or f"task_{info.uuid[:8]}"
         self.webodmOutDir = os.path.join(inputFolder, f"WebODM_{folderKey}")
 
         self.widget.webodmLogTextEdit.clear()

--- a/ODM/ODM.py
+++ b/ODM/ODM.py
@@ -905,6 +905,9 @@ class ODMManager:
             progressDialog.setValue(int(percent))
             slicer.app.processEvents()
 
+        # Report the error only after the progress dialog is down: errorDisplay is modal,
+        # so raising it from the except block would strand the upload dialog behind it.
+        createError = None
         try:
             self.webodmTask = node.create_task(
                 files=files_to_upload,
@@ -913,10 +916,14 @@ class ODMManager:
                 progress_callback=onUploadProgress
             )
         except Exception as e:
-            slicer.util.errorDisplay(f"Task creation failed:\n{str(e)}")
-            return
+            createError = e
         finally:
             progressDialog.close()
+            slicer.app.processEvents()
+
+        if createError is not None:
+            slicer.util.errorDisplay(f"Task creation failed:\n{str(createError)}")
+            return
 
         slicer.util.infoDisplay(
             f"Task '{shortTaskName}' created successfully. Monitoring progress...",

--- a/ODM/ODM.py
+++ b/ODM/ODM.py
@@ -58,6 +58,7 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         self.webodmLogTextEdit = None
         self.stopMonitoringButton = None
         self.cancelTaskButton = None
+        self.reconnectTaskButton = None
         self.nodeDashboardLabel = None
         
         # NodeODM management
@@ -338,6 +339,16 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         self.cancelTaskButton.setToolTip("Cancel the monitored task on the node itself.")
         taskControlRow.addWidget(self.cancelTaskButton)
         webodmTaskFormLayout.addRow(taskControlRow)
+
+        self.reconnectTaskButton = qt.QPushButton("Reconnect to Task on Node...")
+        self.reconnectTaskButton.setToolTip(
+            "Pick up a task that is already on the node - one left behind by 'Stop Monitoring',\n"
+            "or started in an earlier Slicer session - and resume watching it, downloading the\n"
+            "results when it finishes.\n\n"
+            "NodeODM deletes finished tasks after 48 hours by default, so this only reaches\n"
+            "tasks the node still remembers."
+        )
+        webodmTaskFormLayout.addRow(self.reconnectTaskButton)
         
         self.importModelButton = qt.QPushButton("Import Reconstructed Model")
         self.layout.addWidget(self.importModelButton)
@@ -368,6 +379,7 @@ class ODMWidget(ScriptedLoadableModuleWidget):
         self.launchWebODMTaskButton.connect('clicked(bool)', self.onRunWebODMTask)
         self.stopMonitoringButton.connect('clicked(bool)', self.onStopMonitoring)
         self.cancelTaskButton.connect('clicked(bool)', self.onCancelTaskClicked)
+        self.reconnectTaskButton.connect('clicked(bool)', self.onReconnectTaskClicked)
         self.importModelButton.connect('clicked(bool)', self.onImportModelClicked)
         # self.saveTaskButton.connect('clicked(bool)', self.onSaveTaskClicked)
         # self.restoreTaskButton.connect('clicked(bool)', self.onRestoreTaskClicked)
@@ -443,6 +455,10 @@ class ODMWidget(ScriptedLoadableModuleWidget):
     def onCancelTaskClicked(self):
         """Cancel the monitored task on the node"""
         self.webODMManager.onCancelTaskClicked()
+
+    def onReconnectTaskClicked(self):
+        """Resume monitoring a task that is already on the node"""
+        self.webODMManager.onReconnectTaskClicked()
 
     def nodeDashboardUrl(self):
         """URL of the NodeODM dashboard for the currently configured node."""
@@ -765,6 +781,7 @@ class ODMManager:
         """
         hasTask = self.webodmTask is not None
         self.widget.launchWebODMTaskButton.setEnabled(not hasTask)
+        self.widget.reconnectTaskButton.setEnabled(not hasTask)
         self.widget.stopMonitoringButton.setEnabled(hasTask)
         self.widget.cancelTaskButton.setEnabled(hasTask)
 
@@ -1022,6 +1039,114 @@ class ODMManager:
         self._stopMonitoringTimer()
         self.webodmTask = None
         self._updateTaskButtons()
+
+    def describeTask(self, info):
+        """One line per task for the reconnect picker."""
+        stamp = info.date_created.strftime("%Y-%m-%d %H:%M") if info.date_created else "?"
+        return (f"{info.name or '(unnamed)'}  |  {info.status.name}  |  "
+                f"{stamp} UTC  |  {info.images_count} images")
+
+    def onReconnectTaskClicked(self):
+        """
+        Attach to a task that is already on the node -- left running by Stop Monitoring,
+        or started in an earlier Slicer session -- and resume monitoring it, so its
+        results can still be downloaded.
+        """
+        if self.webodmTask is not None:
+            slicer.util.warningDisplay(
+                "A task is already being monitored.\n\nUse 'Stop Monitoring' first."
+            )
+            return
+
+        inputFolder = self.widget.inputFolderSelector.directory
+        if not inputFolder or not os.path.isdir(inputFolder):
+            slicer.util.errorDisplay(
+                "Select the masked images folder first - it is where the results are downloaded to."
+            )
+            return
+
+        try:
+            from pyodm import Node
+        except ImportError:
+            slicer.util.errorDisplay("pyodm module not found. Please install it via pip.")
+            return
+
+        dashboardUrl = self.widget.nodeDashboardUrl()
+        node = Node(self.widget.nodeIPLineEdit.text.strip(), self.widget.nodePortSpinBox.value)
+
+        try:
+            entries = node.get('/task/list') or []
+        except Exception as e:
+            slicer.util.errorDisplay(
+                f"Could not reach NodeODM at {dashboardUrl}\n\n{str(e)}\n\n"
+                "Is the node running? Use 'Launch NodeODM' above to start it."
+            )
+            return
+
+        if not entries:
+            slicer.util.infoDisplay(f"The node at {dashboardUrl} has no tasks.")
+            return
+
+        # /task/list returns UUIDs only, so ask each task for its name/status/date.
+        tasks = []
+        for entry in entries:
+            uuid = entry.get('uuid') if isinstance(entry, dict) else None
+            if not uuid:
+                continue
+            try:
+                tasks.append(node.get_task(uuid).info())
+            except Exception:
+                continue  # vanished between listing and asking; skip it
+
+        if not tasks:
+            slicer.util.warningDisplay(
+                f"The node at {dashboardUrl} listed tasks, but none of them could be read."
+            )
+            return
+
+        tasks.sort(key=lambda i: i.date_created, reverse=True)
+        labels = [self.describeTask(i) for i in tasks]
+
+        # PythonQt's binding for QInputDialog.getItem returns just the selected string
+        # (empty on cancel), not the (value, ok) tuple the C++/PyQt API uses.
+        chosen = qt.QInputDialog.getItem(
+            slicer.util.mainWindow(),
+            "Reconnect to Task",
+            f"Tasks on {dashboardUrl}:",
+            labels,
+            0,
+            False,
+        )
+        if not chosen or chosen not in labels:
+            return
+
+        self.attachToTask(node, tasks[labels.index(chosen)], inputFolder, dashboardUrl)
+
+    def attachToTask(self, node, info, inputFolder, dashboardUrl):
+        """Resume monitoring an existing node task and route its results to disk."""
+        self.webodmTask = node.get_task(info.uuid)
+
+        # The task name is the folder key (WebODM_<name>), which is why names carry a
+        # timestamp. A task created outside Slicer may be unnamed; fall back to its UUID.
+        folderKey = info.name or f"task_{info.uuid[:8]}"
+        self.webodmOutDir = os.path.join(inputFolder, f"WebODM_{folderKey}")
+
+        self.widget.webodmLogTextEdit.clear()
+        self.widget.webodmLogTextEdit.append(f"Reconnected to '{folderKey}' on {dashboardUrl}")
+        self.widget.webodmLogTextEdit.append(f"  node task UUID: {info.uuid}")
+        self.widget.webodmLogTextEdit.append(f"  results will download to: {self.webodmOutDir}")
+
+        self.lastWebODMOutputLineIndex = 0
+        self._stopMonitoringTimer()
+        self.webodmTimer = qt.QTimer()
+        self.webodmTimer.setInterval(5000)
+        self.webodmTimer.timeout.connect(self.checkWebODMTaskStatus)
+        self.webodmTimer.start()
+        self._updateTaskButtons()
+
+        # Poll once now rather than making the user wait for the first tick -- and if the
+        # task already finished, this downloads it immediately.
+        self.checkWebODMTaskStatus()
 
     def queuedTaskCount(self):
         """


### PR DESCRIPTION
## Why

A user queued ~a dozen identical reconstructions without meaning to, saw only `Status: Queued, Progress: 0%` for two hours, and reported it as a hang ([MorphoCloud/Instances#139](https://github.com/MorphoCloud/Instances/issues/139#issuecomment-4969901032)). The support answer was "open Firefox at localhost:3002 and cancel them" — a URL the module never mentions.

Fixing that surfaced a family of related problems: you couldn't tell tasks apart, couldn't get results back if Slicer stopped watching, and couldn't tell which photos a task came from.

## What changed

**Stops the pile-up**
- Run is disabled whenever a task is tracked (`_updateTaskButtons()` is the single source of truth), plus a hard guard in `_runWebODMTask`. Previously every click created another task *and* overwrote `self.webodmTask`, orphaning the last one.
- `node.info()` before creating: it's the first call that proves the node is reachable (`Node.__init__` does no I/O) and it exposes `task_queue_count`, so we can ask before piling on.
- Queue depth in the status line (`count - 1`; NodeODM counts your own task).

**Makes the work visible**
- Upload progress dialog via pyodm's `progress_callback` — the upload runs on the UI thread and used to freeze Slicer silently while the button promised "(non-blocking)".
- Cancel Task (`Task.cancel()`); Stop Monitoring now says the task keeps running.
- A clickable Node Dashboard link that tracks the IP/port fields.

**Makes tasks identifiable**
- Tasks are named after the dataset: `name:` defaults to the images folder's basename and follows the folder selector until you type your own. `UWBM_82409_<settings-hash>_<timestamp>` says which photos, which settings, when. Previously every task was `SlicerReconstruction_<hash>` — a pure function of the *settings*, so two runs collided on the node and on disk, the second download landing on the first.
- `WebODM_<name>.json` record per job, holding the node's task UUID, node URL, image count, images folder and options. An images folder becomes self-describing.
- The results folder is created at download time, not at submit — it used to leave empty folders that looked like output.

**Makes results recoverable**
- **Reconnect to Task on Node…** lists what the node has (`GET /task/list` + `Task.info()`), cross-references the local records to tag which are yours, and resumes monitoring via `Node.get_task(uuid)`. Reconnecting to a finished task downloads it immediately. The module already carried commented-out Save/Restore Task buttons scoped for this.

**Other**
- `matcher-type` defaults to `flann`, ODM's own default, which the tooltip already documented. `bruteforce` was preselected, and since turntable images carry no GPS EXIF OpenSfM [falls back to all-pairs matching](https://github.com/OpenDroneMap/OpenSfM/blob/main/opensfm/pairs_selection.py) — every run was doing exhaustive matching over every pair.
- 38 strings wrote `\\n`, rendering a literal `\n` in dialogs instead of a line break; the other 37 in the same file already used `\n`.

## Testing

Driven on a real MorphoCloud instance against a live GPU NodeODM: upload progress, the queue prompt, Run correctly refusing while monitoring, and Reconnect attaching to a live task all confirmed by the author. Widget behaviour (button states, picker contents/ordering, naming, sanitising, record round-trip, Import folder selection) exercised in a live Slicer with a stubbed node.

Not yet driven end-to-end on Linux: Cancel against a real task, and the task-record/naming work, which postdates the author's session.

## Known, deliberately not in this PR

- `rerun` combo does nothing. It ships `rerun=openmvs` on every task, but NodeODM discards it — [`odmInfo.js:83-88`](https://github.com/OpenDroneMap/NodeODM/blob/master/libs/odmInfo.js#L83-L88) excludes `--rerun` when building its accepted-option list, and unknown options are never read. Inert, not harmful (checked on `master` and `v2.1.0`). Suggest deleting the combo.
- `matcher-neighbors` is GPS-only and inert on no-GPS turntable sets; both `16` and the default `0` end in all-pairs. `--matcher-order` is the filename-order knob, but it doesn't wrap (no loop closure on a 360° set) and ODM ignores it on georeferenced/GCP runs.
- Failure reporting is thin: `"Task failed or canceled"` doesn't say which or why, and `TaskInfo.last_error` is never shown.
- A record is written for a task that later fails, with nothing marking it as failed.
- `download_assets` blocks the UI thread with no progress, as the upload used to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
