### PR TITLE
Add mention-triggered Claude workflow (@claude in issues/PRs)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude
+
+# Interactive responder: run Claude when someone @-mentions it in an issue or PR comment.
+# Uses the Claude GitHub App (Max-subscription OAuth token). contents:write lets it commit
+# fixes to the PR branch. NOTE: GitHub runners have no 3D Slicer, so Claude can edit and reason
+# about the code but cannot visually verify a fix here — verification must happen in Slicer.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Gate on @claude mention AND a trusted author (this is a public repo): without the
+    # author_association check any commenter could trigger a write-capable, paid job.
+    if: >
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+    # Serialize runs per issue/PR so two @claude mentions can't race when pushing to a branch.
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(python3:*),mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,5 +42,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # allowedTools must cover how claude-code-action actually persists a fix: git add/commit
+          # plus the bundled push helper it invokes (scripts/git-push.sh) — it does NOT run a raw
+          # `git push`. That path is pinned to the action's @v1 ref; update it if you bump the action.
           claude_args: |
-            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git checkout:*),Bash(python3:*),mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(git add:*),Bash(git commit:*),Bash(git status:*),Bash(git diff:*),Bash(git checkout:*),Bash(/home/runner/work/_actions/anthropics/claude-code-action/v1/scripts/git-push.sh:*),Bash(python3:*),mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(python3:*),mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git checkout:*),Bash(python3:*),mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds `.github/workflows/claude.yml` so Claude runs when a trusted user (OWNER/MEMBER/COLLABORATOR) `@claude`-mentions it in an issue or PR comment. Lets us hand issues to Claude, complementing the existing `claude-code-review.yml` (which only fires on pull requests).

- Same hardened template already merged into SlicerDenseCorrespondenceAnalysis: `author_association` gate (public repo — otherwise any commenter could trigger a write-capable, paid job) + per-issue/PR `concurrency` group.
- Reuses the existing `CLAUDE_CODE_OAUTH_TOKEN` secret and Claude GitHub App already on this repo.
- Trigger is an `@claude` mention (comment, or issue title/body). App-mode actions only activate once this file is on the default branch, so mentions start working after merge.

Note: GitHub runners have no 3D Slicer, so Claude can edit/reason about code but cannot visually verify a fix — verification still happens in Slicer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)