### PR TITLE
Declare Python dependencies in per-module requirements files

### DIFF
--- a/ClusterPhotos/CMakeLists.txt
+++ b/ClusterPhotos/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
+  Resources/requirements_${MODULE_NAME}.txt
   )
 
 #-----------------------------------------------------------------------------

--- a/ClusterPhotos/ClusterPhotos.py
+++ b/ClusterPhotos/ClusterPhotos.py
@@ -280,45 +280,31 @@ class ClusterPhotosWidget(ScriptedLoadableModuleWidget):
         except Exception as e:
             logging.warning(f"Could not complete PyTorch installation steps: {e}")
 
-        # Pillow
+        # Everything else this module needs is declared in
+        # Resources/requirements_ClusterPhotos.txt, so the set can be read (and
+        # pre-installed) without running the module. Only the packages that are
+        # actually missing are installed here.
+        requirementsPath = self.resourcePath("requirements_ClusterPhotos.txt")
         try:
-            from PIL import Image
-            from PIL.ExifTags import TAGS
+            from slicer.packaging import load_requirements, pip_ensure
         except ImportError:
-            slicer.util.pip_install("pillow")
-            from PIL import Image
-            from PIL.ExifTags import TAGS
+            slicer.util.messageBox(
+                "ClusterPhotos requires 3D Slicer 5.12 or later.\n\n"
+                "On earlier releases, install the packages listed in\n"
+                f"{requirementsPath}\n"
+                "manually, or use the stable-5.10 branch of this extension."
+            )
+            return
 
-        # Transformers
         try:
-            import transformers
-        except ImportError:
-            slicer.util.pip_install("transformers>4.29.2")
-            import transformers
-
-        # scikit-learn
-        try:
-            import sklearn
-        except ImportError:
-            slicer.util.pip_install("scikit-learn")
-            import sklearn
-
-        # umap-learn
-        try:
-            import umap
-        except ImportError:
-            slicer.util.pip_install("umap-learn")
-            import umap
-
-        # OpenCV (optional)
-        try:
-            import cv2
-            if not hasattr(cv2, 'xfeatures2d'):
-                raise ImportError("opencv-contrib-python is not properly installed")
-        except ImportError:
-            slicer.util.pip_install("opencv-python")
-            slicer.util.pip_install("opencv-contrib-python")
-            import cv2
+            pip_ensure(load_requirements(requirementsPath), requester="ClusterPhotos")
+        except Exception as e:
+            logging.warning(f"ClusterPhotos: Python package installation did not complete: {e}")
+            slicer.util.messageBox(
+                "ClusterPhotos cannot be used until the Python packages listed in\n"
+                f"{requirementsPath}\n"
+                "are installed."
+            )
 
     # -------------------------------------------------------------------------
     #   Event handlers

--- a/ClusterPhotos/Resources/requirements_ClusterPhotos.txt
+++ b/ClusterPhotos/Resources/requirements_ClusterPhotos.txt
@@ -1,0 +1,17 @@
+# Python packages required by the ClusterPhotos module.
+#
+# The module installs these on demand (the first time it is opened), but the
+# list is kept here so it can be read - and pre-installed - without running the
+# module, e.g. for offline or restricted-network deployments:
+#
+#   PythonSlicer -m pip install -r requirements_ClusterPhotos.txt
+#
+# torch is deliberately not listed: it is installed through the PyTorch
+# extension (EXTENSION_DEPENDS in the top-level CMakeLists.txt), which picks a
+# build matching the machine's CUDA runtime.
+Pillow
+transformers>4.29.2
+scikit-learn
+umap-learn
+opencv-python
+opencv-contrib-python

--- a/ODM/CMakeLists.txt
+++ b/ODM/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
+  Resources/requirements_${MODULE_NAME}.txt
   )
 
 #-----------------------------------------------------------------------------

--- a/ODM/ODM.py
+++ b/ODM/ODM.py
@@ -423,32 +423,33 @@ class ODMWidget(ScriptedLoadableModuleWidget):
             slicer.util.errorDisplay(f"Failed to create or set permissions for WebODM folder:\n{str(e)}")
     
     def _ensurePyODMInstalled(self):
-        """Check if pyodm is installed, and install it if missing."""
+        """Install this module's Python packages (pyodm) if they are missing.
+
+        The list is declared in Resources/requirements_ODM.txt so that it can be
+        read - and pre-installed - without running the module.
+        """
+        requirementsPath = self.resourcePath("requirements_ODM.txt")
         try:
-            import pyodm  # noqa: F401
-            # Already installed
-            return
+            from slicer.packaging import load_requirements, pip_ensure
         except ImportError:
-            pass
-        
-        # Ask user to install
-        if not slicer.util.confirmOkCancelDisplay(
-            "The ODM module requires the 'pyodm' Python package.\n\n"
-            "Install it now?",
-            "Install pyodm"
-        ):
             slicer.util.warningDisplay(
-                "pyodm is required for this module to function.\n"
-                "You can install it manually via:\n"
-                "pip install pyodm"
+                "The ODM module requires 3D Slicer 5.12 or later.\n\n"
+                "On earlier releases, install the packages listed in\n"
+                f"{requirementsPath}\n"
+                "manually, or use the stable-5.10 branch of this extension."
             )
             return
-        
+
         try:
-            slicer.util.pip_install("pyodm")
-            slicer.util.infoDisplay("pyodm installed successfully!")
+            pip_ensure(load_requirements(requirementsPath), requester="ODM")
         except Exception as e:
-            slicer.util.errorDisplay(f"Failed to install pyodm:\n{e}\n\nPlease install manually:\npip install pyodm")
+            logging.warning(f"ODM: Python package installation did not complete: {e}")
+            slicer.util.warningDisplay(
+                "The ODM module cannot function until the Python packages listed in\n"
+                f"{requirementsPath}\n"
+                "are installed. You can install them manually with:\n"
+                f"PythonSlicer -m pip install -r {requirementsPath}"
+            )
 
     def onLaunchWebODMClicked(self):
         """Launch NodeODM container with GPU support on port 3002"""

--- a/ODM/Resources/requirements_ODM.txt
+++ b/ODM/Resources/requirements_ODM.txt
@@ -1,0 +1,8 @@
+# Python packages required by the ODM module.
+#
+# The module installs these on demand (the first time it is opened), but the
+# list is kept here so it can be read - and pre-installed - without running the
+# module, e.g. for offline or restricted-network deployments:
+#
+#   PythonSlicer -m pip install -r requirements_ODM.txt
+pyodm

--- a/PhotoMasking/CMakeLists.txt
+++ b/PhotoMasking/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
+  Resources/requirements_${MODULE_NAME}.txt
   )
 
 #-----------------------------------------------------------------------------

--- a/PhotoMasking/PhotoMasking.py
+++ b/PhotoMasking/PhotoMasking.py
@@ -520,54 +520,41 @@ class PhotoMaskingWidget(ScriptedLoadableModuleWidget):
         except Exception:
             pass
 
+        # Everything else this module needs - including segment-anything, which
+        # is installed from a GitHub archive - is declared in
+        # Resources/requirements_PhotoMasking.txt, so the set can be read (and
+        # pre-installed) without running the module. Only the packages that are
+        # actually missing are installed here.
+        requirementsPath = self.resourcePath("requirements_PhotoMasking.txt")
         try:
-            from PIL import Image
-            from PIL.ExifTags import TAGS
+            from slicer.packaging import load_requirements, pip_ensure
         except ImportError:
-            slicer.util.pip_install("Pillow")
-            from PIL import Image
-            from PIL.ExifTags import TAGS
-
-        try:
-            import cv2
-            if not hasattr(cv2, 'xfeatures2d'):
-                raise ImportError("opencv-contrib-python is not properly installed")
-        except ImportError:
-            slicer.util.pip_install("opencv-python")
-            slicer.util.pip_install("opencv-contrib-python")
-            import cv2
-
-        try:
-            import segment_anything
-        except ImportError:
-            import os
-            from slicer.util import downloadFile, extractArchive, pip_install
-
-            # 1) Decide where to put the downloaded ZIP locally:
-            modulePath = os.path.dirname(slicer.modules.photomasking.path)
-            resourcesFolder = os.path.join(modulePath, "Resources")
-            if not os.path.isdir(resourcesFolder):
-                os.makedirs(resourcesFolder)
-
-            # 2) Direct download link
-            url = "https://github.com/facebookresearch/segment-anything/archive/refs/heads/main.zip"
-
-            try:
-                pip_install(url)
-            except Exception as e:
-                slicer.util.errorDisplay(f"Failed to pip-install segment-anything from {localExtractDir}:\n{str(e)}")
-                raise
-
-            # 3) Finally, import again
-            import segment_anything
+            slicer.util.messageBox(
+                "PhotoMasking requires 3D Slicer 5.12 or later.\n\n"
+                "On earlier releases, install the packages listed in\n"
+                f"{requirementsPath}\n"
+                "manually, or use the stable-5.10 branch of this extension."
+            )
+            return
 
         try:
-            import matplotlib
-        except ImportError:
-            slicer.util.pip_install("matplotlib")
-            import matplotlib
+            pip_ensure(load_requirements(requirementsPath), requester="PhotoMasking")
+        except Exception as e:
+            logging.warning(f"PhotoMasking: Python package installation did not complete: {e}")
+            slicer.util.messageBox(
+                "PhotoMasking cannot be used until the Python packages listed in\n"
+                f"{requirementsPath}\n"
+                "are installed."
+            )
+            return
 
-        from segment_anything import sam_model_registry, SamPredictor
+        # Report a missing SAM early, but without breaking the module UI: the
+        # install is skipped when Slicer runs in testing mode, and the user may
+        # have declined it.
+        try:
+            from segment_anything import sam_model_registry, SamPredictor  # noqa: F401
+        except ImportError as e:
+            logging.warning(f"PhotoMasking: segment-anything is not available: {e}")
 
     def createCustomLayout(self):
         """

--- a/PhotoMasking/Resources/requirements_PhotoMasking.txt
+++ b/PhotoMasking/Resources/requirements_PhotoMasking.txt
@@ -1,0 +1,22 @@
+# Python packages required by the PhotoMasking module.
+#
+# The module installs these on demand (the first time it is opened), but the
+# list is kept here so it can be read - and pre-installed - without running the
+# module, e.g. for offline or restricted-network deployments:
+#
+#   PythonSlicer -m pip install -r requirements_PhotoMasking.txt
+#
+# torch is deliberately not listed: it is installed through the PyTorch
+# extension (EXTENSION_DEPENDS in the top-level CMakeLists.txt), which picks a
+# build matching the machine's CUDA runtime.
+Pillow
+opencv-python
+opencv-contrib-python
+matplotlib
+
+# segment-anything is not released on PyPI. It is installed straight from the
+# upstream repository archive - which is what PhotoMasking has always done -
+# expressed here as a PEP 508 direct reference so pip can read it from this
+# file too. Note that the archive tracks the upstream 'main' branch, so it is
+# not a reproducible pin.
+segment-anything @ https://github.com/facebookresearch/segment-anything/archive/refs/heads/main.zip

--- a/README.md
+++ b/README.md
@@ -53,6 +53,33 @@ To run locally, you'll need:
 
 > **Note:** Due to Docker installation complexities, the Photogrammetry extension is currently only available in the Slicer Extension Catalogue for Linux. Again, we suggest running the Photogrammetry extension in [MorphoCloud On Demand](https://instances.morpho.cloud) using g3.xl flavor for best performance. 
 
+### Python dependencies
+
+Each module installs the Python packages it needs on demand, so no manual setup is required for normal use. The packages are declared in a requirements file per module, so the set can also be read - and pre-installed - without running the module (useful for pre-provisioned images, offline installs, and restricted networks):
+
+| Module | Requirements file |
+| --- | --- |
+| ClusterPhotos | [`ClusterPhotos/Resources/requirements_ClusterPhotos.txt`](ClusterPhotos/Resources/requirements_ClusterPhotos.txt) |
+| PhotoMasking | [`PhotoMasking/Resources/requirements_PhotoMasking.txt`](PhotoMasking/Resources/requirements_PhotoMasking.txt) |
+| VideoMasking | [`VideoMasking/Resources/requirements_VideoMasking.txt`](VideoMasking/Resources/requirements_VideoMasking.txt) |
+| ODM | [`ODM/Resources/requirements_ODM.txt`](ODM/Resources/requirements_ODM.txt) |
+
+To pre-install them into Slicer's Python environment:
+
+```bash
+PythonSlicer -m pip install -r PhotoMasking/Resources/requirements_PhotoMasking.txt
+```
+
+At runtime the modules load the same files through [`slicer.packaging`](https://github.com/Slicer/Slicer/pull/9010) (Slicer 5.12+), which installs only what is missing.
+
+Three dependencies are not declared in those files:
+
+- **PyTorch** is installed through the [PyTorch](https://github.com/fepegar/SlicerPyTorch) extension (a declared extension dependency), which selects a build matching the machine's CUDA runtime.
+- **SAM2** (VideoMasking) is cloned at configure time from [SlicerMorph/Samurai](https://github.com/SlicerMorph/Samurai) and installed as an editable install, so the spec does not exist until the module has run.
+- **The video decoding backend** (VideoMasking) is either `decord` (preferred) or `av`, depending on which has a wheel for the platform - an either/or a requirements file cannot express.
+
+`segment-anything` (PhotoMasking) has no PyPI release, but *is* declared: the requirements file points pip at the upstream GitHub archive.
+
 ## Sample Data
 
 ### Full Dataset

--- a/VideoMasking/CMakeLists.txt
+++ b/VideoMasking/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
+  Resources/requirements_${MODULE_NAME}.txt
   )
 
 #-----------------------------------------------------------------------------

--- a/VideoMasking/Resources/requirements_VideoMasking.txt
+++ b/VideoMasking/Resources/requirements_VideoMasking.txt
@@ -1,0 +1,43 @@
+# Python packages required by the VideoMasking module.
+#
+# The module installs these on demand (when SAM2 is configured, and again
+# before saving masked frames), but the list is kept here so it can be read -
+# and pre-installed - without running the module, e.g. for offline or
+# restricted-network deployments:
+#
+#   PythonSlicer -m pip install -r requirements_VideoMasking.txt
+#
+# torch is deliberately not listed: it is installed through the PyTorch
+# extension (EXTENSION_DEPENDS in the top-level CMakeLists.txt), which picks a
+# build matching the machine's CUDA runtime.
+
+# SAM2 runtime dependencies
+hydra-core
+omegaconf
+iopath
+loguru
+pandas
+scipy
+opencv-python
+jpeg4py
+lmdb
+
+# Saving masked frames with EXIF metadata
+Pillow
+piexif
+pymediainfo
+
+# Two dependencies cannot be declared here, and are installed by the module
+# itself:
+#
+# - SAM2: cloned at configure time (by default from
+#   https://github.com/SlicerMorph/Samurai.git) and installed editable with
+#   'pip install -e <clone>/sam2', so the spec does not exist until the module
+#   has run.
+#
+# - The video decoding backend: 'decord' is preferred (tried as decord==0.6.0,
+#   then decord==0.6.1, then decord) and 'av' (av==12.2.0, then av) is used
+#   when no decord wheel is available for the platform. A requirements file
+#   cannot express that either/or, and pinning decord here would turn a
+#   working fallback into a hard failure - so pre-install 'decord' if a wheel
+#   exists for your platform, and 'av' otherwise.

--- a/VideoMasking/VideoMasking.py
+++ b/VideoMasking/VideoMasking.py
@@ -639,6 +639,30 @@ class VideoMaskingWidget(ScriptedLoadableModuleWidget):
             raise RuntimeError(f"pip install failed: {spec}")
         return True
 
+    def _install_declared_requirements(self):
+        """
+        Install the PyPI packages declared in Resources/requirements_VideoMasking.txt.
+
+        Keeping the list in a requirements file means it can be read - and
+        pre-installed - without running the module. Only the packages that are
+        actually missing are installed. SAM2 and the video backend are not
+        declarable there and are installed separately (see that file).
+        """
+        requirementsPath = self.resourcePath("requirements_VideoMasking.txt")
+        try:
+            from slicer.packaging import load_requirements, pip_ensure
+        except ImportError as e:
+            raise RuntimeError(
+                "VideoMasking requires 3D Slicer 5.12 or later. On earlier releases, "
+                f"install the packages listed in {requirementsPath} manually, or use "
+                "the stable-5.10 branch of this extension."
+            ) from e
+
+        self._log(f"Installing declared Python packages from {requirementsPath}")
+        # The user already confirmed the (blocking) setup, so do not prompt again.
+        pip_ensure(load_requirements(requirementsPath), requester="VideoMasking",
+                   prompt_install=False)
+
     def _install_python_deps(self, repo_dir: Path):
         """
         Install SAM-2 and its runtime deps in a way that is resilient on Slicer's embedded Python.
@@ -657,19 +681,7 @@ class VideoMaskingWidget(ScriptedLoadableModuleWidget):
             self._log("WARNING: 'sam2' directory not found under repo; will try repo root afterwards.")
 
         # 2) Core runtime deps used in the pipeline
-        base = [
-            "hydra-core",
-            "omegaconf",
-            "iopath",
-            "loguru",
-            "pandas",
-            "scipy",
-            "opencv-python",
-            "jpeg4py",
-            "lmdb",
-        ]
-        for pkg in base:
-            self._pip(pkg, desc=f"pip install {pkg} ?")
+        self._install_declared_requirements()
 
         # 3) Video I/O backends (decord preferred) + verify
         self._ensure_video_backends()
@@ -3060,22 +3072,22 @@ class VideoMaskingWidget(ScriptedLoadableModuleWidget):
         - Pillow (PIL) ? image IO and EXIF writing bridge
         - piexif ? EXIF injection
         - pymediainfo ? extract EXIF-like info from video container
+
+        All three are declared in Resources/requirements_VideoMasking.txt with the
+        rest of the module's packages, so a missing one is installed from there.
         """
         try:
             import PIL  # noqa
-        except Exception:
-            self._pip("Pillow", "Installing Pillow (for EXIF writing)")
-            import PIL  # noqa
-        try:
             import piexif  # noqa
-        except Exception:
-            self._pip("piexif", "Installing piexif (for EXIF injection)")
-            import piexif  # noqa
-        try:
             from pymediainfo import MediaInfo  # noqa
+            return
         except Exception:
-            self._pip("pymediainfo", "Installing pymediainfo (for video metadata)")
-            from pymediainfo import MediaInfo  # noqa
+            pass
+
+        self._install_declared_requirements()
+        import PIL  # noqa
+        import piexif  # noqa
+        from pymediainfo import MediaInfo  # noqa
 
     def _extract_video_metadata(self, video_path: str):
         """

--- a/VideoMasking/VideoMasking.py
+++ b/VideoMasking/VideoMasking.py
@@ -639,7 +639,7 @@ class VideoMaskingWidget(ScriptedLoadableModuleWidget):
             raise RuntimeError(f"pip install failed: {spec}")
         return True
 
-    def _install_declared_requirements(self):
+    def _install_declared_requirements(self, prompt_install: bool = True):
         """
         Install the PyPI packages declared in Resources/requirements_VideoMasking.txt.
 
@@ -647,6 +647,9 @@ class VideoMaskingWidget(ScriptedLoadableModuleWidget):
         pre-installed - without running the module. Only the packages that are
         actually missing are installed. SAM2 and the video backend are not
         declarable there and are installed separately (see that file).
+
+        :param prompt_install: ask before installing. Pass False only where the
+            user has already confirmed an install-heavy operation.
         """
         requirementsPath = self.resourcePath("requirements_VideoMasking.txt")
         try:
@@ -659,9 +662,8 @@ class VideoMaskingWidget(ScriptedLoadableModuleWidget):
             ) from e
 
         self._log(f"Installing declared Python packages from {requirementsPath}")
-        # The user already confirmed the (blocking) setup, so do not prompt again.
         pip_ensure(load_requirements(requirementsPath), requester="VideoMasking",
-                   prompt_install=False)
+                   prompt_install=prompt_install)
 
     def _install_python_deps(self, repo_dir: Path):
         """
@@ -680,8 +682,9 @@ class VideoMaskingWidget(ScriptedLoadableModuleWidget):
         else:
             self._log("WARNING: 'sam2' directory not found under repo; will try repo root afterwards.")
 
-        # 2) Core runtime deps used in the pipeline
-        self._install_declared_requirements()
+        # 2) Core runtime deps used in the pipeline. The user already confirmed
+        #    the (blocking) setup, so do not prompt again here.
+        self._install_declared_requirements(prompt_install=False)
 
         # 3) Video I/O backends (decord preferred) + verify
         self._ensure_video_backends()


### PR DESCRIPTION
Closes #86.

## What this does

Declares each module's Python dependencies in `Resources/requirements_<Module>.txt`, registers those files in the module `CMakeLists.txt` so they ship with the built extension, and loads them at runtime through [`slicer.packaging`](https://github.com/Slicer/Slicer/pull/9010):

```python
requirementsPath = self.resourcePath("requirements_ClusterPhotos.txt")
from slicer.packaging import load_requirements, pip_ensure
pip_ensure(load_requirements(requirementsPath), requester="ClusterPhotos")
```

| Module | Declared packages |
| --- | --- |
| ClusterPhotos | Pillow, transformers>4.29.2, scikit-learn, umap-learn, opencv-python, opencv-contrib-python |
| PhotoMasking | Pillow, opencv-python, opencv-contrib-python, matplotlib, segment-anything (GitHub archive) |
| VideoMasking | hydra-core, omegaconf, iopath, loguru, pandas, scipy, opencv-python, jpeg4py, lmdb, Pillow, piexif, pymediainfo |
| ODM | pyodm |

This picks up where the earlier automated pass on this issue stopped: that one added requirements files only and left the runtime `pip_install` call sites alone, which would have left two copies of the dependency list free to drift. It also did not register the new files with CMake, so they would not have been installed with the extension.

## Behaviour

Same in substance — packages are still installed on demand, when a module needs them. Differences worth knowing:

- `pip_ensure` checks what is already installed first and installs only what is missing, in one pip call and one prompt, instead of one `pip_install` per package.
- It skips installing when Slicer is in testing mode, so the generic module tests no longer pull multi-GB wheels.
- `opencv-contrib-python` is now verified through package metadata rather than `hasattr(cv2, "xfeatures2d")`, which was true for a broken contrib install as well.
- ODM's bespoke "Install pyodm?" dialog is replaced by the standard `pip_ensure` prompt; declining still leaves a message explaining how to install manually.

## The non-PyPI cases

`segment-anything` **is** declared, as a PEP 508 direct reference to the upstream archive, so pip can read it from the file — this replaces the hand-rolled URL install in `PhotoMasking.load_dependencies` (which also referenced an undefined `localExtractDir` in its error path). Note it tracks upstream `main`, so it is not a reproducible pin.

Two dependencies genuinely cannot be declared, and are documented in the requirements files and in the new README section:

- **SAM2** — VideoMasking clones a repo at configure time and installs it editable, so the spec does not exist until the module has run.
- **VideoMasking's video backend** — `decord` (tried as `decord==0.6.0`, `decord==0.6.1`, `decord`), falling back to `av` when no decord wheel exists for the platform. A requirements file cannot express that either/or, and pinning `decord` would turn a working fallback into a hard failure.

`torch` is also excluded: it comes from the PyTorch extension (`EXTENSION_DEPENDS`), which selects a build matching the machine's CUDA runtime.

## Verification

Ran the four modules in a Slicer build (`--testing`, so `pip_ensure` installs nothing):

- all four widgets set up without error;
- `resourcePath()` resolves to each requirements file in both the source and installed layouts (they share one `Resources/` directory once installed, hence the per-module filenames);
- `slicer.packaging.load_requirements()` parses all four files (6 / 5 / 12 / 1 requirements) and `pip_check` evaluates every entry, including the `segment-anything` direct reference.

## Two things worth a maintainer's call

1. **Slicer 5.12 baseline.** `slicer.packaging` landed after 5.10, so this needs 5.12+ on `master`; 5.10 users are served by the `stable-5.10` branch. Each module degrades with a message saying so rather than failing obscurely. Say the word if you would rather have a `pip_install` fallback for older releases.
2. **No version pins.** The declared specs match what the code installs today (unpinned, apart from `transformers>4.29.2`). The resolved set from the MorphoCloud image build would be a good follow-up if you want reproducible pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
